### PR TITLE
[BreakingChange] : Now TaskParameter keeps their object structure.

### DIFF
--- a/valentia/functions/Invokation/CommandExecution/Job/Invoke-Valentia.ps1
+++ b/valentia/functions/Invokation/CommandExecution/Job/Invoke-Valentia.ps1
@@ -86,9 +86,9 @@ function Invoke-Valentia
         [Parameter(
             Position = 3, 
             Mandatory = 0,
-            HelpMessage = "Input parameter pass into task's arg[0....x].")]
+            HelpMessage = "Input parameter pass into task's arg[0....x].values")]
         [ValidateNotNullOrEmpty()]
-        [string[]]
+        [hashtable]
         $TaskParameter,
 
         [Parameter(

--- a/valentia/functions/Invokation/CommandExecution/Job/Private/Invoke-ValentiaCommand.ps1
+++ b/valentia/functions/Invokation/CommandExecution/Job/Private/Invoke-ValentiaCommand.ps1
@@ -62,7 +62,7 @@ function Invoke-ValentiaCommand
             Position = 3, 
             Mandatory = 0,
             HelpMessage = "Input parameter pass into task's arg[0....x].")]
-        [string[]]
+        [hashtable]
         $TaskParameter,
 
         [Parameter(

--- a/valentia/functions/Invokation/CommandExecution/Job/Private/Invoke-ValentiaJobProcess.ps1
+++ b/valentia/functions/Invokation/CommandExecution/Job/Private/Invoke-ValentiaJobProcess.ps1
@@ -20,7 +20,7 @@ function Invoke-ValentiaJobProcess
         $Credential,
 
         [parameter(Mandatory = 0)]
-        [string[]]
+        [hashtable]
         $TaskParameter,
 
         [parameter(Mandatory = 1)]

--- a/valentia/functions/Invokation/CommandExecution/RunSpacePool/Invoke-ValentiaAsync.ps1
+++ b/valentia/functions/Invokation/CommandExecution/RunSpacePool/Invoke-ValentiaAsync.ps1
@@ -87,9 +87,9 @@ function Invoke-ValentiaAsync
         [Parameter(
             Position = 3, 
             Mandatory = 0,
-            HelpMessage = "Input parameter pass into task's arg[0....x].")]
+            HelpMessage = "Input parameter pass into task's arg[0....x].Values")]
         [ValidateNotNullOrEmpty()]
-        [string[]]
+        [hashtable]
         $TaskParameter,
 
         [Parameter(

--- a/valentia/functions/Invokation/CommandExecution/RunSpacePool/Private/AsyncPipeline/Invoke-ValentiaAsyncPipeline.ps1
+++ b/valentia/functions/Invokation/CommandExecution/RunSpacePool/Private/AsyncPipeline/Invoke-ValentiaAsyncPipeline.ps1
@@ -16,7 +16,7 @@ function Invoke-ValentiaAsyncPipeline
         $Credential,
 
         [parameter(Mandatory = 0)]
-        [string[]]
+        [hashtable]
         $TaskParameter,
 
         [parameter(Mandatory = 1)]

--- a/valentia/functions/Invokation/CommandExecution/RunSpacePool/Private/Invoke-ValentiaRunspaceProcess.ps1
+++ b/valentia/functions/Invokation/CommandExecution/RunSpacePool/Private/Invoke-ValentiaRunspaceProcess.ps1
@@ -20,7 +20,7 @@ function Invoke-ValentiaRunspaceProcess
         $Credential,
 
         [parameter(Mandatory = 0)]
-        [string[]]
+        [hashtable]
         $TaskParameter,
 
         [parameter(Mandatory = 1)]


### PR DESCRIPTION
Change TaskParameter from String[] to hashtable.
This cause breaking change to use local variable in valentia  scriptblock.
## Before : 

this cause break for Object structure.

``` Powershell
$hoge = ls
valea 10.0.0.10 {
    param($hoge)
    $hoge
} -TaskParameter $hoge
```
## after 

this keep Object Structure.

``` PowerShell
$hoge = @{hoge = ls}
valea 10.0.0.10 {
    param($hoge)
    $hoge.Values
} -TaskParameter $hoge
```
## Changed

You just need to add `.Values` to get -TaskParameter Object.
